### PR TITLE
Fix OGP fetch: fallback via r.jina.ai

### DIFF
--- a/api/internal/handler/links.go
+++ b/api/internal/handler/links.go
@@ -238,6 +238,11 @@ func (h *LinksHandler) GetOGP(c *gin.Context) {
 		return
 	}
 
+	// Helpful for debugging in devtools when some sites return empty OGP due to bot protections.
+	if meta != nil && meta.Source != "" {
+		c.Header("X-QuickLinks-OGP-Source", meta.Source)
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"title":       meta.Title,
 		"description": meta.Description,

--- a/api/internal/service/metadata.go
+++ b/api/internal/service/metadata.go
@@ -1,8 +1,14 @@
 package service
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
@@ -12,18 +18,137 @@ type Metadata struct {
 	Title       string
 	Description string
 	Image       string
+	Source      string
 }
 
 // FetchMetadata scrapes the URL to find OGP title, description, and image.
 func FetchMetadata(targetURL string) (*Metadata, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	req, err := http.NewRequest("GET", targetURL, nil)
+	meta, status, err := fetchAndParse(ctx, client, targetURL)
 	if err != nil {
 		return nil, err
 	}
+	// If direct fetch likely hit bot protection (or no useful tags), try a proxy fetch.
+	//
+	// Note: Some sites behind Cloudflare may return "Just a moment..." pages to cloud IPs
+	// (even with a browser UA), resulting in empty OG tags.
+	if status != 200 || looksLikeBotChallenge(meta.Title) || (meta.Image == "" && meta.Title == "" && meta.Description == "") {
+		jinaURL := "https://r.jina.ai/" + targetURL
+		fb, _, fbErr := fetchAndParse(ctx, client, jinaURL)
+		if fbErr != nil {
+			log.Printf("failed to fetch metadata via jina proxy: %v (target=%s)", fbErr, targetURL)
+			return meta, nil
+		}
+		merged := mergePreferExisting(meta, fb)
+		merged.Source = "jina"
+		return merged, nil
+	}
+
+	meta.Source = "direct"
+	return meta, nil
+}
+
+func looksLikeBotChallenge(title string) bool {
+	t := strings.ToLower(strings.TrimSpace(title))
+	return strings.Contains(t, "just a moment") || strings.Contains(t, "attention required") || strings.Contains(t, "cloudflare")
+}
+
+func mergePreferExisting(primary, fallback *Metadata) *Metadata {
+	out := &Metadata{
+		Title:       primary.Title,
+		Description: primary.Description,
+		Image:       primary.Image,
+		Source:      primary.Source,
+	}
+	if out.Title == "" {
+		out.Title = fallback.Title
+	}
+	if out.Description == "" {
+		out.Description = fallback.Description
+	}
+	if out.Image == "" {
+		out.Image = fallback.Image
+	}
+	return out
+}
+
+func fetchAndParse(ctx context.Context, client *http.Client, target string) (*Metadata, int, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", target, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	applyBrowserHeaders(req)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, 2<<20)) // 2MB cap
+	if err != nil {
+		return nil, res.StatusCode, err
+	}
+
+	m := &Metadata{}
+
+	// Try HTML OG tags first.
+	if doc, err := goquery.NewDocumentFromReader(bytes.NewReader(body)); err == nil {
+		// Helpers: sites sometimes use `property` or `name`.
+		getMeta := func(key string) string {
+			keyEsc := strings.ReplaceAll(key, "'", "\\'")
+			if v := strings.TrimSpace(doc.Find("meta[property='"+keyEsc+"']").AttrOr("content", "")); v != "" {
+				return v
+			}
+			if v := strings.TrimSpace(doc.Find("meta[name='"+keyEsc+"']").AttrOr("content", "")); v != "" {
+				return v
+			}
+			return ""
+		}
+
+		// Title
+		m.Title = firstNonEmpty(
+			getMeta("og:title"),
+			getMeta("twitter:title"),
+			strings.TrimSpace(doc.Find("title").Text()),
+		)
+		// Description
+		m.Description = firstNonEmpty(
+			getMeta("og:description"),
+			getMeta("twitter:description"),
+			getMeta("description"),
+		)
+		// Image
+		m.Image = firstNonEmpty(
+			getMeta("og:image"),
+			getMeta("og:image:url"),
+			getMeta("twitter:image"),
+			getMeta("twitter:image:src"),
+		)
+
+		// Resolve relative image URLs if any.
+		if m.Image != "" {
+			m.Image = resolveMaybeRelativeURL(target, m.Image)
+		}
+	}
+
+	// If still missing image, try extracting from jina's Markdown/plain content.
+	if m.Image == "" {
+		text := string(body)
+		m.Title = firstNonEmpty(m.Title, parseJinaTitle(text))
+		m.Image = firstNonEmpty(m.Image, extractFirstImageURL(text))
+	}
+
+	return m, res.StatusCode, nil
+}
+
+func applyBrowserHeaders(req *http.Request) {
 	// Some sites (e.g. behind Cloudflare) may block obvious bot UAs from cloud IPs.
 	// Use a browser-like UA to improve fetch success rates.
 	req.Header.Set(
@@ -32,47 +157,63 @@ func FetchMetadata(targetURL string) (*Metadata, error) {
 	)
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "ja,en-US;q=0.9,en;q=0.8")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Pragma", "no-cache")
+}
 
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			return v
+		}
 	}
-	defer res.Body.Close()
+	return ""
+}
 
-	if res.StatusCode != 200 {
-		log.Printf("failed to fetch metadata: status %d", res.StatusCode)
-		return &Metadata{}, nil // Return empty metadata on non-200
+func resolveMaybeRelativeURL(baseStr, u string) string {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		return ""
 	}
-
-	doc, err := goquery.NewDocumentFromReader(res.Body)
-	if err != nil {
-		return nil, err
+	parsed, err := url.Parse(u)
+	if err == nil && parsed.IsAbs() {
+		return u
 	}
-
-	meta := &Metadata{}
-
-	// Helper to get meta content
-	getContent := func(property string) string {
-		return doc.Find("meta[property='"+property+"']").AttrOr("content", "")
+	base, err := url.Parse(baseStr)
+	if err != nil || base == nil {
+		return u
 	}
-	getNameContent := func(name string) string {
-		return doc.Find("meta[name='"+name+"']").AttrOr("content", "")
+	if parsed == nil {
+		parsed, _ = url.Parse(u)
 	}
-
-	// Title
-	meta.Title = getContent("og:title")
-	if meta.Title == "" {
-		meta.Title = doc.Find("title").Text()
+	if parsed == nil {
+		return u
 	}
+	return base.ResolveReference(parsed).String()
+}
 
-	// Description
-	meta.Description = getContent("og:description")
-	if meta.Description == "" {
-		meta.Description = getNameContent("description")
+func parseJinaTitle(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Title:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Title:"))
+		}
 	}
+	return ""
+}
 
-	// Image
-	meta.Image = getContent("og:image")
+var (
+	reMarkdownImage = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^)\s]+)\)`)
+	reImageURL      = regexp.MustCompile(`https?://[^\s)]+?\.(?:png|jpe?g|webp)(?:\?[^\s)]*)?`)
+)
 
-	return meta, nil
+func extractFirstImageURL(text string) string {
+	if m := reMarkdownImage.FindStringSubmatch(text); len(m) == 2 {
+		return strings.TrimRight(m[1], ")")
+	}
+	if m := reImageURL.FindString(text); m != "" {
+		return strings.TrimRight(m, ")")
+	}
+	return ""
 }


### PR DESCRIPTION
## Why（なぜ）

一部のサイト（例: openai.com）は、Cloudflare などの bot 対策によりクラウドIPから取得すると OGP が空で返る ことがあります。

その結果、/api/og は 200 を返しているにも関わらず、

```json
{ "title": "", "description": "", "image": "" }
```

のような 有効なメタデータが取得できない状態 になります。
（※ブラウザで見ると普通に OGP が存在するため、判別しづらい）

## What（何をしたか）

- meta タグ抽出を改善
    - property / name の両方に対応
    - twitter:* 系メタタグもサポート

- 通常の fetch がブロック／空データの場合に `https://r.jina.ai/<url>` を使ったフォールバック取得を追加

- デバッグ用にレスポンスヘッダ `X-QuickLinks-OGP-Source: direct | jina` を付与

## Notes（補足）

- r.jina.ai は HTML ではなく markdown / plain text を返す
- OGP 構造は取得できないため、最初に出現する画像 URL を実用的なフォールバックとして使用
- 精度は下がるが、「OGP が完全に空になる」問題を回避できる